### PR TITLE
Add `CustomStringConvertible` conformances

### DIFF
--- a/Sources/PeriodDuration/Duration/Duration+Description.swift
+++ b/Sources/PeriodDuration/Duration/Duration+Description.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension Duration: CustomStringConvertible {
+    public var description: String {
+        [
+            hours.map { "\($0) hour\($0 == 1 ? "" : "s")" },
+            minutes.map { "\($0) minute\($0 == 1 ? "" : "s")" },
+            seconds.map { "\($0) second\($0 == 1 ? "" : "s")" },
+        ]
+        .lazy
+        .compactMap { $0 }
+        .joined(separator: ", ")
+    }
+}

--- a/Sources/PeriodDuration/Period/Period+Description.swift
+++ b/Sources/PeriodDuration/Period/Period+Description.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension Period: CustomStringConvertible {
+    public var description: String {
+        [
+            years.map { "\($0) year\($0 == 1 ? "" : "s")" },
+            months.map { "\($0) month\($0 == 1 ? "" : "s")" },
+            days.map { "\($0) day\($0 == 1 ? "" : "s")" },
+        ]
+        .lazy
+        .compactMap { $0 }
+        .joined(separator: ", ")
+    }
+}

--- a/Sources/PeriodDuration/PeriodDuration/PeriodDuration+Description.swift
+++ b/Sources/PeriodDuration/PeriodDuration/PeriodDuration+Description.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension PeriodDuration: CustomStringConvertible {
+    public var description: String {
+        [
+            self.years.map { "\($0) year\($0 == 1 ? "" : "s")" },
+            self.months.map { "\($0) month\($0 == 1 ? "" : "s")" },
+            self.days.map { "\($0) day\($0 == 1 ? "" : "s")" },
+            self.hours.map { "\($0) hour\($0 == 1 ? "" : "s")" },
+            self.minutes.map { "\($0) minute\($0 == 1 ? "" : "s")" },
+            self.seconds.map { "\($0) second\($0 == 1 ? "" : "s")" },
+        ]
+        .lazy
+        .compactMap { $0 }
+        .joined(separator: ", ")
+    }
+}

--- a/Tests/PeriodDurationTests/DescriptionTests.swift
+++ b/Tests/PeriodDurationTests/DescriptionTests.swift
@@ -1,0 +1,61 @@
+import PeriodDuration
+import XCTest
+
+final class DescriptionTests: XCTestCase {
+    func testPeriodDurationDescription() {
+        XCTAssertEqual(
+            PeriodDuration(blankProps).description,
+            ""
+        )
+        XCTAssertEqual(
+            PeriodDuration(zeroProps).description,
+            "0 years, 0 months, 0 days, 0 hours, 0 minutes, 0 seconds"
+        )
+        XCTAssertEqual(
+            PeriodDuration(years: 1, months: 1, days: 1, hours: 1, minutes: 1, seconds: 1).description,
+            "1 year, 1 month, 1 day, 1 hour, 1 minute, 1 second"
+        )
+        XCTAssertEqual(
+            PeriodDuration(years: 3, months: 3, days: 3, hours: 3, minutes: 3, seconds: 3).description,
+            "3 years, 3 months, 3 days, 3 hours, 3 minutes, 3 seconds"
+        )
+    }
+
+    func testPeriodDescription() {
+        XCTAssertEqual(
+            Period(blankProps).description,
+            ""
+        )
+        XCTAssertEqual(
+            Period(zeroProps).description,
+            "0 years, 0 months, 0 days"
+        )
+        XCTAssertEqual(
+            Period(years: 1, months: 1, days: 1).description,
+            "1 year, 1 month, 1 day"
+        )
+        XCTAssertEqual(
+            Period(years: 3, months: 3, days: 3).description,
+            "3 years, 3 months, 3 days"
+        )
+    }
+
+    func testDurationDescription() {
+        XCTAssertEqual(
+            Duration(blankProps).description,
+            ""
+        )
+        XCTAssertEqual(
+            Duration(zeroProps).description,
+            "0 hours, 0 minutes, 0 seconds"
+        )
+        XCTAssertEqual(
+            Duration(hours: 1, minutes: 1, seconds: 1).description,
+            "1 hour, 1 minute, 1 second"
+        )
+        XCTAssertEqual(
+            Duration(hours: 3, minutes: 3, seconds: 3).description,
+            "3 hours, 3 minutes, 3 seconds"
+        )
+    }
+}


### PR DESCRIPTION
Helps get a human-readable representation for platforms where `DateComponentsFormatter` isn't available (namely Linux).