### PR TITLE
CI: Add Swift 6.3 to Linux and Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         swift:
           - "6.1"
           - "6.2"
-          # TODO: Add "6.3" when swift:6.3 Docker image is available
+          - "6.3"
     container:
       image: swift:${{ matrix.swift }}
     steps:
@@ -116,7 +116,7 @@ jobs:
         swift:
           - "6.1"
           - "6.2"
-          # TODO: Add "6.3" when swift:6.3 Docker image is available
+          - "6.3"
     steps:
       - name: Git Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Add Swift 6.3 to the Linux and Android CI matrices now that the `swift:6.3` Docker image is available
- Remove the corresponding TODO comments